### PR TITLE
Updating Zenodo DOI

### DIFF
--- a/jose.00037/10.21105.jose.00037.crossref.xml
+++ b/jose.00037/10.21105.jose.00037.crossref.xml
@@ -60,7 +60,7 @@
         <rel:program>
           <rel:related_item>
             <rel:description>Software archive</rel:description>
-            <rel:inter_work_relation relationship-type="references" identifier-type="doi">https://doi.org/10.5281/zenodo.2546005</rel:inter_work_relation>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">https://doi.org/10.5281/zenodo.2546004</rel:inter_work_relation>
           </rel:related_item>
           <rel:related_item>
             <rel:description>GitHub review issue</rel:description>


### PR DESCRIPTION
I've recently released v1.1.0 of these lessons on GitHub, which automatically created a new page (and DOI) on Zenodo. I have updated the JOSE paper so that it uses the DOI 10.5281/zenodo.2546004, which represents all versions and will always resolve to the latest one.